### PR TITLE
Dependencies update

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -42,7 +42,7 @@ then
 fi
 
 ## installing the correct dependencies:
-apt-get -y install x11vnc
+apt-get -y install oracle-java8-jdk x11vnc
 if [ $? -ne 0 ]
 then
   error "Failed to install dependencies"

--- a/setup.sh
+++ b/setup.sh
@@ -41,8 +41,8 @@ then
   error "Failed to unpack JMRI sources into /opt"
 fi
 
-## installing the correct java txrx library:
-apt-get -y install openjdk-7-jre librxtx-java x11vnc
+## installing the correct dependencies:
+apt-get -y install x11vnc
 if [ $? -ne 0 ]
 then
   error "Failed to install dependencies"


### PR DESCRIPTION
JMRI needs a 1.8 JRE (plus Raspbian has come pre-installed with Oracle JDK 1.8 for quite some time). This is usually installed out-of-the-box with Raspbian so should not normally be required, but belt-and-braces.
A suitable RXTX is already packaged within JMRI.
